### PR TITLE
Update OG metadata for Game Design Club

### DIFF
--- a/app/guides/[slug]/page.tsx
+++ b/app/guides/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation"
+import type { Metadata } from "next"
 import { createSupabaseServerClient } from "@/lib/supabase/server"
 import GuidePageClient, { type GuideData } from "./guide-page-client"
 
@@ -7,6 +8,40 @@ import GuidePageClient, { type GuideData } from "./guide-page-client"
  * SUPABASE_SERVICE_ROLE_KEY & SUPABASE_URL.  No client-side code here!
  */
 export const revalidate = 0
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { slug: string }
+}): Promise<Metadata> {
+  const supabase = createSupabaseServerClient()
+  const { data } = await supabase
+    .from("guides")
+    .select("guide_data")
+    .eq("slug", params.slug)
+    .single()
+
+  if (!data) {
+    return {}
+  }
+
+  const guideData = data.guide_data as GuideData
+
+  const title = `${guideData.gameName} | Game Design Club`
+  const description = guideData.gameSubtitle
+
+  return {
+    title,
+    description,
+    openGraph: { images: "/IMG_6499.png", title, description },
+    twitter: {
+      card: "summary_large_image",
+      images: "/IMG_6499.png",
+      title,
+      description,
+    },
+  }
+}
 
 export default async function GuidePage({
   params,

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,9 +16,20 @@ const pressStart2P = Press_Start_2P({
 })
 
 export const metadata: Metadata = {
-  title: "RDS Game Design Club",
-  description: "Summer 2025 • Learn game design through play and analysis",
+  title: "Game Design Club",
+  description: "Play more games • Make more games",
   generator: "v0.dev",
+  openGraph: {
+    images: "/IMG_6499.png",
+    title: "Game Design Club",
+    description: "Play more games • Make more games",
+  },
+  twitter: {
+    card: "summary_large_image",
+    images: "/IMG_6499.png",
+    title: "Game Design Club",
+    description: "Play more games • Make more games",
+  },
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- set default metadata image and title/description for the site
- generate guide page metadata dynamically

## Testing
- `pnpm install`
- `pnpm lint` *(fails: requires interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_6881e24b647c8330a2c9159d5d6bcb8f