### PR TITLE
Add R2B2 snippet

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -35,6 +35,13 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning className={pressStart2P.variable}>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `!function(){var reb2b=window.reb2b=window.reb2b||[];if(reb2b.invoked)return;reb2b.invoked=!0;reb2b.methods=["identify","collect"];reb2b.factory=function(method){return function(){var args=Array.prototype.slice.call(arguments);args.unshift(method);reb2b.push(args);return reb2b;}};for(var i=0;i<reb2b.methods.length;i++){var key=reb2b.methods[i];reb2b[key]=reb2b.factory(key);}reb2b.load=function(key){var script=document.createElement("script");script.type="text/javascript";script.async=!0;script.src="https://b2bjsstore.s3.us-west-2.amazonaws.com/b/"+key+"/QO92DH7955N7.js.gz";var first=document.getElementsByTagName("script")[0];first.parentNode.insertBefore(script,first);};reb2b.SNIPPET_VERSION="1.0.1";reb2b.load("QO92DH7955N7");}();`,
+          }}
+        />
+      </head>
       <body className="antialiased">
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false} disableTransitionOnChange>
           {/* PostHogProvider (client) uses useSearchParams – keep inside Suspense */}


### PR DESCRIPTION
## Summary
- inject the provided R2B2 script directly into `app/layout.tsx` so it loads in `<head>`

## Testing
- `pnpm install --frozen-lockfile`
- `npm run lint` *(fails: prompts for config)*
- `npm run build` *(fails: cannot fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6882be2ce79483309376b8ca113b18bb