### PR TITLE
chore: clarify universal principle subtitles

### DIFF
--- a/app/actions/generate-guide.ts
+++ b/app/actions/generate-guide.ts
@@ -56,6 +56,8 @@ You must return ONLY a valid JSON object. Do not include any other text, markdow
 }
 \`\`\`
 
+Remember: the subtitles in quotes are meant to be universal game principles and game design mechanics, not game-specific lingo. The goal is to use this guide to drive a conversation about how and where certain universal game design principles were uniquely applied to this game in particular, while teaching the concept of the game design principles and game design dynamics.
+
 ---
 
 ### 📋 Content Requirements


### PR DESCRIPTION
## Summary
- remind guide generator that subtitles should reference universal game principles, not game-specific terms

## Testing
- `pnpm lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68936ec3cb8c8330ac017af818c37ff1